### PR TITLE
React deprecated PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jest": "^18.1.0",
     "mocha": "^3.2.0",
     "mocha-jsdom": "^1.1.0",
+    "prop-types": "^15.5.10",
     "react": "latest",
     "react-dom": "^15.4.2",
     "react-redux": "^4.0.0",

--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,6 @@
 /*eslint-disable no-unused-vars*/
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Lifecycle extends Component {
 	static propTypes = {


### PR DESCRIPTION
# React deprecated PropTypes
This is a hotfix to update way we access PropTypes as the old method has been deprecated, in [React v15.5](https://facebook.github.io/react/warnings/dont-call-proptypes.html), which was to access PropTypes through the main React package using the named PropTypes export.

This hotfix will fix the follow error message that is shown in the console screenshot below.

<img width="732" alt="screen shot 2017-05-30 at 22 41 14" src="https://cloud.githubusercontent.com/assets/19606031/26606425/bebc76c4-4589-11e7-98d6-8a7d4cb37d71.png">
